### PR TITLE
Fix issue id 1

### DIFF
--- a/src/migrations/2013_07_24_070421_create_attachmentables_table.php
+++ b/src/migrations/2013_07_24_070421_create_attachmentables_table.php
@@ -36,7 +36,9 @@ class CreateAttachmentablesTable extends Migration {
      */
     public function down()
     {
-        Schema::dropForeign('attachmentables_attachment_id_foreign');
+        Schema::table('attachmentables', function($table) {
+            $table->dropForeign('attachmentables_attachment_id_foreign');
+        });
 
         Schema::dropIfExists('attachmentables');
     }


### PR DESCRIPTION
Hi,

On the migration file:

```
2013_07_24_070421_create_attachmentables_table.php
```

The next code is wrong:

```
Schema::dropForeign('attachmentables_attachment_id_foreign');
```

Thats not the correct code for do a dropForeign, the code must be:

```
Schema::table('attachmentables', function($table) {
    $table->dropForeign('attachmentables_attachment_id_foreign');
});
```

You can see at:

http://laravel.com/docs/schema#foreign-keys

Actually the migrations works, buy when you try to migrate::rollback, Fatal error dropped.

Also, **that drop is not needed**, if you just commend that line, the rollback is done because you create the tables in nice order with foreign keys.

Hope it helps you.
